### PR TITLE
Bump scalafmt to v3.8.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.15"
+version = "3.8.0"
 maxColumn = 120
 align.preset = most
 align.multiline = false


### PR DESCRIPTION
Reference https://github.com/scalameta/scalafmt/releases/tag/v3.8.0