### PR TITLE
Bump Scanamo to 4.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val upickleVersion        = "4.2.1"
 lazy val cirisVersion          = "3.9.0"
 lazy val zioInteropCatsVersion = "23.1.0.3"
 lazy val pureconfigVersion     = "0.17.9"
-lazy val scanamoVersion        = "3.0.0"
+lazy val scanamoVersion        = "4.0.0"
 lazy val tethysVersion         = "0.29.5"
 lazy val catsVersion           = "2.13.0"
 


### PR DESCRIPTION
We currently cannot upgrade to the latest release of Scanamo because it conflicts with the neotype-transitive dependency:

<img width="895" height="183" alt="Screenshot 2025-08-12 at 11 08 39" src="https://github.com/user-attachments/assets/990a0215-ee52-4263-a5bf-3b5d9f2a77ab" />

This PR therefore bumps the Scanamo version.

From Scanamo's release notes it seems non-critical:

> Although this release includes a major version bump, to Scanamo 4.0.0, there are no radical changes to the Scanamo API from the most recent previous version, 3.0.0. The version bump is calculated automatically by [sbt-version-policy](https://github.com/scalacenter/sbt-version-policy) as part of the [gha-scala-library-release-workflow](https://github.com/guardian/gha-scala-library-release-workflow), and ensures that sbt will not permit two different versions of Scanamo with potential binary compatibility to coexist in the same app.

https://github.com/scanamo/scanamo/releases/tag/v4.0.0