### PR TITLE
Adjust Custom FromExpr[Option[A]] for Scala 3.8

### DIFF
--- a/modules/core/shared/src/main/scala/neotype/eval/CustomFromExpr.scala
+++ b/modules/core/shared/src/main/scala/neotype/eval/CustomFromExpr.scala
@@ -66,10 +66,10 @@ object CustomFromExpr:
           @nowarn("msg=unused")
           given Type[A] = aType.asInstanceOf[Type[A]]
           x match
-            case '{ Option[A](${ Expr(a) }) } => Some(Some(a))
-            case '{ Some[A](${ Expr(a) }) }   => Some(Some(a))
-            case '{ None }                    => Some(None)
-            case _                            => None
+            case '{ Option[A](${ Expr(a) }: A) } => Some(Some(a))
+            case '{ Some[A](${ Expr(a) }) }      => Some(Some(a))
+            case '{ None }                       => Some(None)
+            case _                               => None
 
   given fromExprEither[E, A]: FromExpr[Either[E, A]] with
     def unapply(x: Expr[Either[E, A]])(using Quotes) =


### PR DESCRIPTION
Tweak to custom implementation of `FromExpr[Option[A]]` to make it compile under Scala 3.8. The type annotation is required to narrow `A | Null` into just `A`. Scala 3.8 would ship with standard library compiled using Scala 3 including some adjustments to signatures 
Issue detected by Open Community Build - https://github.com/VirtusLab/community-build3/actions/runs/18606867633/job/53059126390

The issue is triggered because `Option.apply` is now defined as `def apply[T](value: T | Null): Option[T]` instead of `def apply[T](value: T): Option[T]`
 
Based on the current upstream implementation https://github.com/scala/scala3/blame/9ff48b1629601d6c7d4f766254180d917f2c7161/library/src/scala/quoted/FromExpr.scala#L100-L112 

Note: I'm not sure if the rhs should probably be `Some(Option(a))`, or was a deliberate decision for this variant of `FromExpr`