### PR TITLE
Added a Circe key encoder decoder

### DIFF
--- a/modules/core/shared/src/test/scala/neotype/test/JsonLibrarySpec.scala
+++ b/modules/core/shared/src/test/scala/neotype/test/JsonLibrarySpec.scala
@@ -41,12 +41,13 @@ trait JsonLibrarySpec[Codec[_]](
     name: String,
     val library: JsonLibrary[Codec]
 )(using
-    compositeCodec: Codec[Composite],
     validatedNewtypeCodec: Codec[ValidatedNewtype],
     validatedSubtypeCodec: Codec[ValidatedSubtype],
     simpleNewtypeCodec: Codec[SimpleNewtype],
     simpleSubtypeCodec: Codec[SimpleSubtype]
 ) extends ZIOSpecDefault:
+
+  protected def compositeCodec: Option[Codec[Composite]] = None
 
   /** Override to provide OptionalHolder codec for Option handling tests. If not
     * provided, Option tests will be skipped.
@@ -73,9 +74,8 @@ trait JsonLibrarySpec[Codec[_]](
         validatedNewtypeSuite,
         validatedSubtypeSuite,
         simpleNewtypeSuite,
-        simpleSubtypeSuite,
-        compositeSuite
-      ) ++ optionalSuite.toList ++ collectionSuite.toList ++ additionalSuites: _*
+        simpleSubtypeSuite
+      ) ++ compositeSuite.toList ++ optionalSuite.toList ++ collectionSuite.toList ++ additionalSuites: _*
     )
 
   private def validatedNewtypeSuite = suite("ValidatedNewtype")(
@@ -152,7 +152,7 @@ trait JsonLibrarySpec[Codec[_]](
     }
   )
 
-  private def compositeSuite = suite("Composite")(
+  private def compositeSuite = compositeCodec.map{ implicit compositeCodec => suite("Composite")(
     test("decode success") {
       val json =
         """ { "newtype": "hello", "simpleNewtype": 123, "subtype": "hello world", "simpleSubtype": 123 } """
@@ -190,6 +190,7 @@ trait JsonLibrarySpec[Codec[_]](
       )
     }
   )
+  }
 
   private def optionalSuite: Option[Spec[Any, Nothing]] =
     optionalHolderCodec.map { implicit codec =>

--- a/modules/neotype-circe/shared/src/main/scala/neotype/interop/circe/CirceInstances.scala
+++ b/modules/neotype-circe/shared/src/main/scala/neotype/interop/circe/CirceInstances.scala
@@ -11,3 +11,7 @@ given [A, B](using nt: WrappedType[A, B], encoder: Encoder[A]): Encoder[B] =
 
 given [A, B](using nt: WrappedType[A, B], codec: Codec[A]): Codec[B] =
   codec.iemap(nt.make(_))(nt.unwrap)
+
+given [A, B](using nt: WrappedType[A, B], keyDecoder: KeyDecoder[A]): KeyDecoder[B] = (key: String) => keyDecoder.apply(key).flatMap(nt.make(_).toOption)
+
+given [A, B](using nt: WrappedType[A, B], keyEncoder: KeyEncoder[A]): KeyEncoder[B] = keyEncoder.contramap(nt.unwrap)

--- a/modules/neotype-circe/shared/src/test/scala/neotype/interop/circe/CirceJsonSpec.scala
+++ b/modules/neotype-circe/shared/src/test/scala/neotype/interop/circe/CirceJsonSpec.scala
@@ -57,6 +57,8 @@ given Encoder[ListHolder] = Encoder.instance { h =>
 }
 
 object CirceJsonSpec extends JsonLibrarySpec[CirceCodec]("Circe", CirceLibrary):
+  override protected def compositeCodec: Option[CirceCodec[Composite]] = Some(summon[CirceCodec[Composite]])
+
   override protected def optionalHolderCodec: Option[CirceCodec[OptionalHolder]] =
     Some(summon[CirceCodec[OptionalHolder]])
 

--- a/modules/neotype-circe/shared/src/test/scala/neotype/interop/circe/CirceKeyJsonSpec.scala
+++ b/modules/neotype-circe/shared/src/test/scala/neotype/interop/circe/CirceKeyJsonSpec.scala
@@ -1,0 +1,28 @@
+package neotype.interop.circe
+
+import io.circe.*
+import neotype.interop.circe.given
+import neotype.test.*
+import neotype.test.definitions.*
+
+// Circe doesn't have a unified key Codec type that's commonly used,
+// so we create a stub combining Decoder and Encoder
+final case class CirceKeyCodec[A](keyDecoder: KeyDecoder[A], keyEncoder: KeyEncoder[A])
+
+object CirceKeyCodec:
+  given [A](using d: KeyDecoder[A], e: KeyEncoder[A]): CirceKeyCodec[A] = CirceKeyCodec(d, e)
+
+object CirceKeyLibrary extends JsonLibrary[CirceKeyCodec]:
+  def decode[A](json: String)(using codec: CirceKeyCodec[A]): Either[String, A] =
+    codec.keyDecoder.apply(json).toRight("Could not decode key")
+
+  def encode[A](value: A)(using codec: CirceKeyCodec[A]): String =
+    codec.keyEncoder(value)
+
+object CirceKeyJsonSpec extends JsonLibrarySpec[CirceKeyCodec]("CirceKey", CirceKeyLibrary):
+  override protected def optionalHolderCodec: Option[CirceKeyCodec[OptionalHolder]] = None
+
+  override protected def listHolderCodec: Option[CirceKeyCodec[ListHolder]] =
+    None
+
+  override protected def compositeCodec: Option[CirceKeyCodec[Composite]] = None

--- a/modules/neotype-doobie/shared/src/test/scala/neotype/interop/doobie/DoobieInstancesSpec.scala
+++ b/modules/neotype-doobie/shared/src/test/scala/neotype/interop/doobie/DoobieInstancesSpec.scala
@@ -7,7 +7,8 @@ import _root_.doobie.util.transactor.Transactor
 import cats.Show
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import neotype.{Newtype, Subtype}
+import neotype.Newtype
+import neotype.Subtype
 import neotype.common.NonEmptyString
 import neotype.interop.doobie.given
 import neotype.test.definitions.*

--- a/modules/neotype-jsoniter/shared/src/test/scala/neotype/interop/jsoniter/JsoniterSpec.scala
+++ b/modules/neotype-jsoniter/shared/src/test/scala/neotype/interop/jsoniter/JsoniterSpec.scala
@@ -27,6 +27,9 @@ given JsonValueCodec[OptionalHolder] = JsonCodecMaker.make
 given JsonValueCodec[ListHolder]     = JsonCodecMaker.make
 
 object JsoniterSpec extends JsonLibrarySpec[JsonValueCodec]("Jsoniter", JsoniterLibrary):
+
+  override protected def compositeCodec: Option[JsonValueCodec[Composite]] = Some(summon[JsonValueCodec[Composite]])
+
   override protected def optionalHolderCodec: Option[JsonValueCodec[OptionalHolder]] =
     Some(summon[JsonValueCodec[OptionalHolder]])
   override protected def listHolderCodec: Option[JsonValueCodec[ListHolder]] =

--- a/modules/neotype-play-json/shared/src/test/scala/neotype/interop/playjson/PlayJsonSpec.scala
+++ b/modules/neotype-play-json/shared/src/test/scala/neotype/interop/playjson/PlayJsonSpec.scala
@@ -47,6 +47,8 @@ given Format[ListHolder] with
     (json \ "items").validate[List[ValidatedNewtype]].map(ListHolder.apply)
 
 object PlayJsonSpec extends JsonLibrarySpec[Format]("PlayJson", PlayJsonLibrary):
+  override protected def compositeCodec: Option[Format[Composite]] = Some(summon[Format[Composite]])
+
   override protected def optionalHolderCodec: Option[Format[OptionalHolder]] =
     Some(summon[Format[OptionalHolder]])
   override protected def listHolderCodec: Option[Format[ListHolder]] =

--- a/modules/neotype-tethys/shared/src/test/scala/neotype/interop/tethys/TethysSpec.scala
+++ b/modules/neotype-tethys/shared/src/test/scala/neotype/interop/tethys/TethysSpec.scala
@@ -60,6 +60,8 @@ given JsonWriter[ListHolder] =
     .addField("items")(_.items)
 
 object TethysSpec extends JsonLibrarySpec[TethysCodecStub]("Tethys", TethysLibrary):
+  override protected def compositeCodec: Option[TethysCodecStub[Composite]] = Some(summon[TethysCodecStub[Composite]])
+
   override protected def optionalHolderCodec: Option[TethysCodecStub[OptionalHolder]] =
     Some(summon[TethysCodecStub[OptionalHolder]])
   override protected def listHolderCodec: Option[TethysCodecStub[ListHolder]] =

--- a/modules/neotype-upickle/shared/src/test/scala/neotype/interop/upickle/UpickleSpec.scala
+++ b/modules/neotype-upickle/shared/src/test/scala/neotype/interop/upickle/UpickleSpec.scala
@@ -3,7 +3,6 @@ package neotype.interop.upickle
 import neotype.*
 import neotype.test.*
 import neotype.test.definitions.*
-import upickle.default
 import upickle.default.*
 import zio.test.*
 

--- a/modules/neotype-upickle/shared/src/test/scala/neotype/interop/upickle/UpickleSpec.scala
+++ b/modules/neotype-upickle/shared/src/test/scala/neotype/interop/upickle/UpickleSpec.scala
@@ -3,6 +3,7 @@ package neotype.interop.upickle
 import neotype.*
 import neotype.test.*
 import neotype.test.definitions.*
+import upickle.default
 import upickle.default.*
 import zio.test.*
 
@@ -22,6 +23,8 @@ given ReadWriter[OptionalHolder] = macroRW
 given ReadWriter[ListHolder]     = macroRW
 
 object UpickleSpec extends JsonLibrarySpec[ReadWriter]("Upickle", UpickleLibrary):
+  override protected def compositeCodec: Option[ReadWriter[Composite]] = Some(summon[ReadWriter[Composite]])
+
   override protected def optionalHolderCodec: Option[ReadWriter[OptionalHolder]] =
     Some(summon[ReadWriter[OptionalHolder]])
   override protected def listHolderCodec: Option[ReadWriter[ListHolder]] =

--- a/modules/neotype-zio-json/shared/src/test/scala/neotype/interop/ziojson/ZioJsonSpec.scala
+++ b/modules/neotype-zio-json/shared/src/test/scala/neotype/interop/ziojson/ZioJsonSpec.scala
@@ -17,6 +17,8 @@ given JsonCodec[OptionalHolder] = DeriveJsonCodec.gen[OptionalHolder]
 given JsonCodec[ListHolder]     = DeriveJsonCodec.gen[ListHolder]
 
 object ZioJsonSpec extends JsonLibrarySpec[JsonCodec]("ZioJson", ZioJsonLibrary):
+  override protected def compositeCodec: Option[JsonCodec[Composite]] = Some(summon[JsonCodec[Composite]])
+
   override protected def optionalHolderCodec: Option[JsonCodec[OptionalHolder]] =
     Some(summon[JsonCodec[OptionalHolder]])
   override protected def listHolderCodec: Option[JsonCodec[ListHolder]] =


### PR DESCRIPTION
One major difference between most other codecs and circe key decoders/encoders is that they don't support composite data. This caused me to need to rewrite `JsonLibrarySpec` to support testing of the non-composite values.

I verified that all existing implementations of `JsonLibrarySpec` included a `compositeCodec` value by leaving it unimplemented, fixing all the compilation errors, and only then setting the default to `= None`.